### PR TITLE
Related to #296:Resource download with param

### DIFF
--- a/test/test_get.py
+++ b/test/test_get.py
@@ -337,3 +337,20 @@ def test_path_splitted(downloader):
     paths = downloader.download(resourc1, resource2)
     assert isinstance(paths, list)
     assert len(paths) == 3  # if len(paths) == 3, then not splitted
+
+
+def test_download_with_parameter():
+    downloader = Downloader(cache_dir=None)
+    resource = Resource(
+        name="zenodo",
+        url_s="https://zenodo.org/records/7773985/files/CollecTRI_source.tsv?download=1",
+        lifetime=1,
+    )
+
+    paths1 = downloader.download(resource)
+    assert isinstance(paths1, list)
+    assert os.path.exists(paths1[0])
+
+    # load resource from cache
+    paths2 = downloader.download(resource)
+    assert "tmp" in paths2[0]


### PR DESCRIPTION
add a test method `test_download_with_parameter` for downloading resource with query parameter.